### PR TITLE
Fix Debian 11 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ dnsdist is automatically restarted after configuration changes, unless the role 
 
 ## Requirements
 
-Debian or Ubuntu
+Debian 11 (Bullseye)
 
 ## Role Variables
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,12 +8,9 @@ galaxy_info:
   min_ansible_version: 2.4
 
   platforms:
-  - name: Ubuntu
-    versions:
-    - xenial
   - name: Debian
     versions:
-    - stretch
+    - bullseye
 
   galaxy_tags:
     - dns

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,8 +28,8 @@
     dest: /etc/dnsdist/dnsdist.conf
     content: "{{ dnsdist_config }}"
     mode: 0640
-    owner: root
-    group: root
+    owner: _dnsdist
+    group: _dnsdist
   notify: Restart dnsdist
 
 - name: Create override directory


### PR DESCRIPTION
In Debian 11 the pdns.service is run by user `_dnsdist`.